### PR TITLE
[RFC][NI] Lazy load remark images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
     {
       resolve: `gatsby-remark-images`,
       options: {
-        maxWidth: 900,
+        maxWidth: 900
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,6 +24,12 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
+      resolve: `gatsby-remark-images`,
+      options: {
+        maxWidth: 900,
+      },
+    },
+    {
       resolve: `gatsby-plugin-manifest`,
       options: {
         name: `gatsby-starter-default`,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-react-helmet": "^3.1.13",
     "gatsby-plugin-sass": "^2.1.20",
     "gatsby-plugin-sharp": "^2.2.34",
+    "gatsby-remark-images": "^3.1.29",
     "gatsby-source-filesystem": "^2.1.35",
     "gatsby-transformer-remark": "^2.6.32",
     "gatsby-transformer-sharp": "^2.3.1",

--- a/src/components/citiesSection.js
+++ b/src/components/citiesSection.js
@@ -6,7 +6,6 @@ const CitiesSection = ({ data: cityNodes }) => {
     const table = [];
 
     for (const cityNode of cityNodes) {
-      console.log(cityNode);
       const { 
         node: { 
           frontmatter: {
@@ -24,7 +23,7 @@ const CitiesSection = ({ data: cityNodes }) => {
             <Img 
               imgStyle={{ objectFit: 'fill' }} 
               style={{ height: '100%', width: '100%' }} 
-              fluid={image.childImageSharp.fluid}
+              sizes={image.childImageSharp.sizes}
             />
             <h4> {name} </h4>
           </a>

--- a/src/components/countrySection.js
+++ b/src/components/countrySection.js
@@ -20,7 +20,7 @@ const CountrySection = (props) => {
         <Img 
           imgStyle={{ objectFit: 'fill' }}
           style={{ height: '100%', width: '100%'}}
-          fluid={countryImage.childImageSharp.fluid}
+          sizes={countryImage.childImageSharp.sizes}
         />
       </div>
       <div className="country__intro__info">
@@ -38,7 +38,11 @@ const CountrySection = (props) => {
             </div>
           </div>
           <div className="country__intro__info__attributes__right-block">
-            <Img fluid={flagImage.childImageSharp.fluid} />
+            <Img
+              imgStyle={{ objectFit: 'fill' }}
+              style={{ height: '100%', width: '100%'}} 
+              sizes={flagImage.childImageSharp.sizes}
+            />
           </div>    
         </div>
         <div className="country__intro__info__description">

--- a/src/pages/accommodation.js
+++ b/src/pages/accommodation.js
@@ -76,7 +76,7 @@ export const fluidImage = graphql`
   fragment flagsImageFrag on File {
     publicURL
     childImageSharp {
-      sizes(maxWidth: 30 ) {
+      sizes(maxWidth: 30) {
         srcSet
       }
     }
@@ -84,7 +84,7 @@ export const fluidImage = graphql`
   fragment countriesImageFrag on File {
     publicURL
     childImageSharp {
-      sizes(maxWidth: 700 ) {
+      sizes(maxWidth: 700) {
         srcSet
       }
     }
@@ -92,7 +92,7 @@ export const fluidImage = graphql`
   fragment citiesImageFrag on File {
     publicURL
     childImageSharp {
-      sizes(maxWidth: 400 ) {
+      sizes(maxWidth: 400) {
         srcSet
       }
     }

--- a/src/pages/accommodation.js
+++ b/src/pages/accommodation.js
@@ -73,24 +73,27 @@ const IndexPage = ({
 }
 
 export const fluidImage = graphql`
-  fragment fluidFlagsImage on File {
+  fragment flagsImageFrag on File {
+    publicURL
     childImageSharp {
-      fluid(maxWidth: 40) {
-        ...GatsbyImageSharpFluid
+      sizes(maxWidth: 30 ) {
+        srcSet
       }
     }
   },
-  fragment fluidCountriesImage on File {
+  fragment countriesImageFrag on File {
+    publicURL
     childImageSharp {
-      fluid(maxWidth: 700) {
-        ...GatsbyImageSharpFluid
+      sizes(maxWidth: 700 ) {
+        srcSet
       }
     }
   },
-  fragment fluidCitiesImage on File {
+  fragment citiesImageFrag on File {
+    publicURL
     childImageSharp {
-      fluid(maxWidth: 400) {
-        ...GatsbyImageSharpFluid
+      sizes(maxWidth: 400 ) {
+        srcSet
       }
     }
   }
@@ -112,10 +115,10 @@ export const countriesQuery = graphql`
             currencyCode
             callingCode
             countryImage {
-              ...fluidCountriesImage
+              ...countriesImageFrag
             }
             flagImage {
-              ...fluidFlagsImage
+              ...flagsImageFrag
             }
           }
 
@@ -132,12 +135,7 @@ export const countriesQuery = graphql`
             name
             slug
             image {
-              publicURL
-              childImageSharp {
-                sizes(maxWidth: 700 ) {
-                  srcSet
-                }
-              }
+              ...citiesImageFrag
             }
           }
         }

--- a/src/pages/accommodation.js
+++ b/src/pages/accommodation.js
@@ -132,7 +132,12 @@ export const countriesQuery = graphql`
             name
             slug
             image {
-              ...fluidCitiesImage
+              publicURL
+              childImageSharp {
+                sizes(maxWidth: 700 ) {
+                  srcSet
+                }
+              }
             }
           }
         }

--- a/src/pages/accommodation.scss
+++ b/src/pages/accommodation.scss
@@ -116,7 +116,7 @@
 
         &__right-block {
           height: 20px;
-          width: 40px;
+          width: 30px;
         }
       }
 

--- a/src/pages/accommodation.scss
+++ b/src/pages/accommodation.scss
@@ -163,6 +163,7 @@
       position: absolute;
       background: #FFF;
       border-radius: 2px;
+      white-space: nowrap;
       padding: 0 50px;
       height: 58px;
       top: 50%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5439,6 +5439,23 @@ gatsby-react-router-scroll@^2.1.14:
     scroll-behavior "^0.9.10"
     warning "^3.0.0"
 
+gatsby-remark-images@^3.1.29:
+  version "3.1.29"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.1.29.tgz#b40c641b7a62fc776149a6dbcb8940f76dbc6749"
+  integrity sha512-VUnuR7ZUSkfA5l/j9Ez8U0J4jx0bdqzeiiI8ftlwjhDjuvoPU1eOFLLULjnwod3p8mX8PIVo5vcdQGL+TtcAwQ==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.3"
+    is-relative-url "^3.0.0"
+    lodash "^4.17.15"
+    mdast-util-definitions "^1.2.4"
+    potrace "^2.1.2"
+    query-string "^6.8.3"
+    slash "^3.0.0"
+    unist-util-select "^1.5.0"
+    unist-util-visit-parents "^2.1.2"
+
 gatsby-source-filesystem@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.35.tgz#b0ae2de06b1100fa9f48e79a2f290e5a82d2d4ff"
@@ -7926,7 +7943,7 @@ mdast-util-compact@^1.0.0:
   dependencies:
     unist-util-visit "^1.1.0"
 
-mdast-util-definitions@^1.2.0:
+mdast-util-definitions@^1.2.0, mdast-util-definitions@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.4.tgz#2b54ad4eecaff9d9fcb6bf6f9f6b68b232d77ca7"
   integrity sha512-HfUArPog1j4Z78Xlzy9Q4aHLnrF/7fb57cooTHypyGoe2XFNbcx/kWZDoOz+ra8CkUzvg3+VHV434yqEd1DRmA==
@@ -10088,6 +10105,15 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.8.3:
+  version "6.8.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
+  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -11455,6 +11481,11 @@ spdy@^4.0.1:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11599,6 +11630,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -12462,7 +12498,7 @@ unist-util-visit-children@^1.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.3.tgz#92ba5807e3f54637be5de950263f9468942e7503"
   integrity sha512-/GQ8KNRrG+qD30H76FZNc6Ok+8XTu8lxJByN5LnQ4eQfqxda2gP0CPsCX63BRB26ZRMNf6i1c+jlvNlqysEoFg==
 
-unist-util-visit-parents@^2.0.0:
+unist-util-visit-parents@^2.0.0, unist-util-visit-parents@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
   integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==


### PR DESCRIPTION
``gatsby-remark-images`` is an official plugin that applies the features (such as lazy-load and more) of ``gatsby-images`` to images loaded directly from markdown files